### PR TITLE
Add .gitattributes for consistent line endings and export-ignore rules

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,89 @@
+# Auto detect text files and perform LF normalization
+* text=auto
+
+# Source code
+*.py text eol=lf
+*.js text eol=lf
+*.ts text eol=lf
+*.jsx text eol=lf
+*.tsx text eol=lf
+*.json text eol=lf
+*.md text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf
+*.toml text eol=lf
+*.cfg text eol=lf
+*.ini text eol=lf
+
+# Shell scripts
+*.sh text eol=lf
+*.bash text eol=lf
+
+# Documentation
+*.rst text eol=lf
+*.txt text eol=lf
+
+# Configuration files
+.editorconfig text eol=lf
+.gitignore text eol=lf
+.gitattributes text eol=lf
+Dockerfile text eol=lf
+*.dockerfile text eol=lf
+Makefile text eol=lf
+*.mk text eol=lf
+
+# Windows batch files
+*.bat text eol=crlf
+*.cmd text eol=crlf
+
+# Binary files
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.pdf binary
+*.zip binary
+*.tar.gz binary
+*.whl binary
+
+# Jupyter notebooks
+*.ipynb text eol=lf
+
+# Lock files (generated, don't modify line endings)
+package-lock.json -text
+poetry.lock -text
+Pipfile.lock -text
+
+# Archives and large files
+*.7z binary
+*.dmg binary
+*.gz binary
+*.iso binary
+*.jar binary
+*.rar binary
+*.tar binary
+*.zip binary
+
+# Fonts
+*.ttf binary
+*.woff binary
+*.woff2 binary
+*.eot binary
+
+# Audio/Video
+*.mp3 binary
+*.mp4 binary
+*.avi binary
+*.mov binary
+*.wav binary
+
+# Exclude files and directories from exports
+.github/ export-ignore
+.gitignore export-ignore
+.gitattributes export-ignore
+*.md export-ignore
+docs/ export-ignore
+tests/ export-ignore
+benchmarks/ export-ignore
+examples/ export-ignore


### PR DESCRIPTION
## Summary
- Introduces a new `.gitattributes` file to the repository
- Ensures consistent line ending normalization across different file types
- Specifies text files to use LF line endings and Windows batch files to use CRLF
- Marks binary files appropriately to prevent line ending conversions
- Adds export-ignore rules for certain files and directories to exclude them from archive exports

## Changes

### Repository Configuration
- Created `.gitattributes` with 89 lines defining:
  - Auto detection and normalization of text files with LF endings
  - Explicit line ending settings for source code, shell scripts, documentation, configuration files, and more
  - Binary file patterns to avoid line ending changes
  - Export-ignore directives for `.github/`, `.gitignore`, `.gitattributes`, markdown files, docs, tests, benchmarks, and examples

## Test plan
- Verify that text files have consistent LF line endings after checkout
- Confirm that Windows batch files use CRLF line endings
- Check that binary files are not altered by Git line ending normalization
- Validate that export-ignore rules exclude specified files and directories from generated archives

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/02ced0de-0205-4d37-942f-e60b027165bc